### PR TITLE
Modify popuplar-posts, recent-posts css

### DIFF
--- a/assets/styl/App/Sidebar/_Post.styl
+++ b/assets/styl/App/Sidebar/_Post.styl
@@ -2,6 +2,7 @@
   #sidebar__popular-posts, #sidebar__recent-posts
     li
       display flex
+      justify-content space-between
       .metainfo
         TextOverflowHidden()
         .date
@@ -11,6 +12,7 @@
       .thumbnail
         height 45px
         width 60px
+        min-width 60px
         object-fit cover
         margin-left 10px
         background-color white //- NT


### PR DESCRIPTION
안녕하세요.

블로그 스킨 좌측의 인기 글과 최근 글의 li 태그가 좌측의 제목길이에 따라
좌우측 정렬이 흐트러지는 것 같아요.

또한, 우측 사진 너비도 최소가로값을 정해주면 조금더 보기 좋을 것 같아 수정해보았어요. 😅

![images_044](https://user-images.githubusercontent.com/87857542/127008245-471145f3-1f78-419f-9915-07c2af639780.png)
![images_045](https://user-images.githubusercontent.com/87857542/127008315-afd1fdaa-0dba-4c32-a857-d47517fb8f3e.png)
