### PR TITLE
fix: 헤딩 앵커 링크 변환 시 HTML 포맷팅 보존하도록 수정

### DIFF
--- a/assets/pug/Mixins/Permalink/Content.pug
+++ b/assets/pug/Mixins/Permalink/Content.pug
@@ -173,10 +173,16 @@ script(once='alpine-article-component').
      */
     setAnchorToHeading ($heading, index) {
       const link = this.link($heading, index)
-      const $anchor = this.$anchor($heading, `#${link}`)
 
       $heading.setAttribute('id', link)
-      $heading.innerHTML = $anchor.outerHTML
+      
+      const originalHTML = $heading.innerHTML
+      const $anchor = document.createElement('a')
+      $anchor.setAttribute('href', `#${link}`)
+      $anchor.innerHTML = originalHTML
+      
+      $heading.innerHTML = ''
+      $heading.appendChild($anchor)
     },
 
     /**

--- a/assets/pug/Mixins/Permalink/Content.pug
+++ b/assets/pug/Mixins/Permalink/Content.pug
@@ -173,14 +173,10 @@ script(once='alpine-article-component').
      */
     setAnchorToHeading ($heading, index) {
       const link = this.link($heading, index)
+      const $anchor = this.$anchor($heading, `#${link}`)
 
       $heading.setAttribute('id', link)
-      const originalHTML = $heading.innerHTML
-      const $anchor = document.createElement('a')
-      $anchor.setAttribute('href', `#${link}`)
-      $anchor.innerHTML = originalHTML
-      $heading.innerHTML = ''
-      $heading.appendChild($anchor)
+      $heading.innerHTML = $anchor.outerHTML
     },
 
     /**
@@ -207,7 +203,7 @@ script(once='alpine-article-component').
       const $anchor = document.createElement('a')
 
       $anchor.setAttribute('href', link)
-      $anchor.textContent = $heading.textContent
+      $anchor.innerHTML = $heading.innerHTML
 
       return $anchor
     },

--- a/assets/pug/Mixins/Permalink/Content.pug
+++ b/assets/pug/Mixins/Permalink/Content.pug
@@ -175,12 +175,10 @@ script(once='alpine-article-component').
       const link = this.link($heading, index)
 
       $heading.setAttribute('id', link)
-      
       const originalHTML = $heading.innerHTML
       const $anchor = document.createElement('a')
       $anchor.setAttribute('href', `#${link}`)
       $anchor.innerHTML = originalHTML
-      
       $heading.innerHTML = ''
       $heading.appendChild($anchor)
     },


### PR DESCRIPTION
closes #282

##  문제점

헤딩에 굵게, 기울임 등의 서식이 적용된 경우, 앵커 링크로 변환되는 과정에서 HTML 서식이 제거되어 시각적 스타일이 사라지는 문제가 있었습니다.

**수정 전:**
```html
<h2>제목 <b>굵은 텍스트</b></h2>
↓ (앵커 변환 후)
<h2 id="heading-1"><a href="#heading-1">제목 굵은 텍스트</a></h2>  <!-- <b> 태그 사라짐 -->
```

**수정 후:**
```html
<h2>제목 <b>굵은 텍스트</b></h2>
↓ (앵커 변환 후) 
<h2 id="heading-1"><a href="#heading-1">제목 <b>굵은 텍스트</b></a></h2>  <!-- <b> 태그 보존 -->
```

##  해결방법

`Content.pug`의 `setAnchorToHeading` 메서드에서 `textContent` 대신 `innerHTML`을 사용하도록 변경:

- **기존**: `textContent`는 모든 HTML 태그를 제거
- **수정**: `innerHTML`은 원본 HTML 구조를 보존

## 변경사항

- `assets/pug/Mixins/Permalink/Content.pug` 수정
  - 179줄: `textContent`에서 `innerHTML`로 변경
  - 182줄: 앵커 요소에 `innerHTML` 설정

## 테스트 결과

- [x] 굵게 서식이 적용된 헤딩이 올바르게 표시됨
- [x] 앵커 링크 기능 정상 작동
- [x] 기존 기능에 대한 호환성 문제 없음

## 스크린샷
<img width="1428" height="466" alt="스크린샷 2025-10-31 오전 12 31 06" src="https://github.com/user-attachments/assets/a1c867a3-16cf-4f52-aadc-c3e5a1f90e42" />

